### PR TITLE
Update recent openings and add new internship positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ To contribute:
 | [ShopBack](https://jobs.lever.co/shopback-2/3c60180b-6dd1-48a6-9d0e-4edf80be1fc3) | One-North | Summer | Internship period is Sept-Dec 2020 or Jan-May 2021 |
 | [Shopee](https://careers.shopee.sg/job-detail/2336/) | Kent-Ridge | All-year around | |
 | [Stripe](https://stripe.com/jobs/listing/software-engineering-intern/3368637) | Outram Park | Summer | |
+| [Temasek](https://career2.successfactors.eu/career?company=temasekcapP2) | Orchard Road | Summer | SWE, Data Science, ML & Dev Ops Positions |
 | [Titansoft](https://www.titansoft.com/en/career/current-openings?country=singapore&tag=3) | Outram Park | Summer | |
 | [Traverse](https://www.traverse.ai/about-us/contact) | Commonwealth | Unknown | No position listed but they do accept interns |
 | [Twitter](https://careers.twitter.com/content/careers-twitter/en/jobs.html#location=careers-twitter%3Asr%2Foffice%2Fsingapore) | Raffles Place/Downtown | Summer | |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To contribute:
 | [JPMorgan](https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/job/210141619)| | Summer | Closes 31 Oct 2021 |
 | [Jump Trading](https://www.jumptrading.com/jobs.html) | Downtown | Summer | SWE and Tech Ops Positions |
 | [Lazada](https://www.lazada.com/en/careers/job-description/GP655404/) | Tanjong Pagar | Summer | Data Analyst Position |
+| [Motional](https://motional.com/careers/positions) | Fusionopolis | Unknown | ML, CV, Research & Systems Engineering Positions; 3-5 months depending on role |
 | [Ninja Van](https://jobs.lever.co/ninjavan?location=Singapore%2C%20Singapore&department=Tech&commitment=Internship) | Alexandra | All-year-round | |
 | [OpenGovProducts](https://opengovernmentproducts.recruitee.com/o/software-engineering-intern)| Funan | All-year-round | Only Singaporeans or PRs allowed |
 | [PayPal](https://jobsearch.paypal-corp.com/en-US/search?facetcountry=sg&location=Singapore&facetcategory=internship) | Promenade | All-year around | |

--- a/README.md
+++ b/README.md
@@ -22,21 +22,21 @@ To contribute:
 | [Citi](https://jobs.citi.com/job/singapore/icg-technology-software-development-2022-summer-analyst-singapore/287/12532326144) | Marina View | Summer | Software Development under their Summer Analyst Program |
 | [CVWO](https://www.comp.nus.edu.sg/~vwo/contact.html) | NUS | Summer | SWE Intern (Predominantly for NUS students) |
 | [DRW](https://drw.com/careers/job/software-developer-intern-1933017/) | Downtown/Marina Bay | Summer | |
-| [Facebook](https://www.facebook.com/careers/jobs/?offices%5B0%5D=Singapore&roles%5B0%5D=intern&is_leadership=0&is_in_page=0) | Marina One | Summer | Software Engineer and Enterprise Engineer Positions |
+| [Facebook](https://www.facebook.com/careers/jobs/?offices%5B0%5D=Singapore&roles%5B0%5D=intern&is_leadership=0&is_in_page=0) | Marina One | Summer | SWE and Enterprise Engineer positions |
 | [FireVisor](https://angel.co/firevisor/jobs) | One-North / City Hall | All-year around | No tech internship positions listed currently |
 | [Foodpanda](https://boards.greenhouse.io/foodpandasingapore/jobs/2399062) | Unknown | All-year around | |
 | [Go-Jek](https://www.gojek.io/careers/) | Tanjong Pagar | Summer | No tech internship positions listed currently |
 | [Goldman Sachs](https://www.goldmansachs.com/careers/students/programs/asia-pacific/summer-analyst.html) | Tanjong Pagar | Summer | Closes 11 Oct 2021
-| [Google](https://careers.google.com/jobs/results/?employment_type=INTERN&location=Singapore&q=) | Pasir Panjang | Summer | SWE and Data Center Technician Positions | Within 12-18 months of completing a Bachelor's or Master's degree
+| [Google](https://careers.google.com/jobs/results/?employment_type=INTERN&location=Singapore&q=) | Pasir Panjang | Summer | SWE and Data Center Technician positions | Within 12-18 months of completing a Bachelor's or Master's degree
 | [Google (STEP)](https://careers.google.com/jobs/results/111206685625721542/) | Pasir Panjang | Summer | Closes 30 Sep 2021 | Only open to second year undergraduate students
 | [GovTech](https://sggovterp.wd102.myworkdayjobs.com/PublicServiceCareers/4/refreshFacet/318c8bb6f553100021d223d9780d30be) | Depends on team | Summer | Multiple positions open |
-| [Grab](https://grab.careers/jobs/) | Marina One | Unknown | 6-month Jan-Jun; Engineering and Data Science Positions |
-| [HopeTechnik](https://www.hopetechnik.com/careers/) | Jurong | All-year around | Software Engineering, Technical Analyst & Mechanical Engineering Positions |
+| [Grab](https://grab.careers/jobs/) | Marina One | Unknown | 6-month Jan-Jun; Engineering and Data Science positions |
+| [HopeTechnik](https://www.hopetechnik.com/careers/) | Jurong | All-year around | Software Engineering, Technical Analyst and Mechanical Engineering positions |
 | [IBM](https://careers.ibm.com/job/13539646/internship-software-developer-jan-to-may-jun-singapore-sg/?codes=IBM_CareerWebSite) | Changi Business Park | Unknown | 6-month Jan-Jun |
 | [JPMorgan](https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/job/210141619)| | Summer | Closes 31 Oct 2021 |
-| [Jump Trading](https://www.jumptrading.com/jobs.html) | Downtown | Summer | SWE and Tech Ops Positions |
-| [Lazada](https://www.lazada.com/en/careers/job-description/GP655404/) | Tanjong Pagar | Summer | Data Analyst Position |
-| [Motional](https://motional.com/careers/positions) | Fusionopolis | Unknown | ML, CV, Research & Systems Engineering Positions; 3-5 months depending on role |
+| [Jump Trading](https://www.jumptrading.com/jobs.html) | Downtown | Summer | SWE and Tech Ops positions |
+| [Lazada](https://www.lazada.com/en/careers/job-description/GP655404/) | Tanjong Pagar | Summer | Data Analyst position |
+| [Motional](https://motional.com/careers/positions) | Fusionopolis | Unknown | ML, CV, Research and Systems Engineering positions; 3-5 months depending on role |
 | [Ninja Van](https://jobs.lever.co/ninjavan?location=Singapore%2C%20Singapore&department=Tech&commitment=Internship) | Alexandra | All-year-round | |
 | [OpenGovProducts](https://opengovernmentproducts.recruitee.com/o/software-engineering-intern)| Funan | All-year-round | Only Singaporeans or PRs allowed |
 | [PayPal](https://jobsearch.paypal-corp.com/en-US/search?facetcountry=sg&location=Singapore&facetcategory=internship) | Promenade | All-year around | |
@@ -45,7 +45,7 @@ To contribute:
 | [ShopBack](https://jobs.lever.co/shopback-2/3c60180b-6dd1-48a6-9d0e-4edf80be1fc3) | One-North | Summer | Internship period is Sept-Dec 2020 or Jan-May 2021 |
 | [Shopee](https://careers.shopee.sg/job-detail/2336/) | Kent-Ridge | All-year around | |
 | [Stripe](https://stripe.com/jobs/listing/software-engineering-intern/3368637) | Outram Park | Summer | |
-| [Temasek](https://career2.successfactors.eu/career?company=temasekcapP2) | Orchard Road | Summer | SWE, Data Science, ML & Dev Ops Positions |
+| [Temasek](https://career2.successfactors.eu/career?company=temasekcapP2) | Orchard Road | Summer | SWE, Data Science, ML and Dev Ops positions |
 | [Titansoft](https://www.titansoft.com/en/career/current-openings?country=singapore&tag=3) | Outram Park | Summer | |
 | [Traverse](https://www.traverse.ai/about-us/contact) | Commonwealth | Unknown | No position listed but they do accept interns |
 | [Twitter](https://careers.twitter.com/content/careers-twitter/en/jobs.html#location=careers-twitter%3Asr%2Foffice%2Fsingapore) | Raffles Place/Downtown | Summer | |

--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ To contribute:
 | [Circles.Life](https://www.circles.life/sg/job-board/) | Unknown | January 2021 | iOS, Android, Web and general SWE positions |
 | [CVWO](https://www.comp.nus.edu.sg/~vwo/contact.html) | NUS | Summer | SWE Intern (Predominantly for NUS students) |
 | [DRW](https://drw.com/careers/job/software-developer-intern-1933017/) | Downtown/Marina Bay | Summer | |
-| [Facebook](https://www.facebook.com/careers/jobs/?offices%5B0%5D=Singapore&roles%5B0%5D=intern&is_leadership=0&is_in_page=0) | Marina One | Summer | Software Engineer and Enterprise Engineer Internships |
+| [Facebook](https://www.facebook.com/careers/jobs/?offices%5B0%5D=Singapore&roles%5B0%5D=intern&is_leadership=0&is_in_page=0) | Marina One | Summer | Software Engineer and Enterprise Engineer Positions |
 | [FireVisor](https://angel.co/firevisor/jobs) | One-North / City Hall | All-year around | No tech internship positions listed currently |
-| [Foodpanda](https://boards.greenhouse.io/foodpandasingapore/jobs/2399062) | Unknown | All-year around | SWE Intern |
+| [Foodpanda](https://boards.greenhouse.io/foodpandasingapore/jobs/2399062) | Unknown | All-year around | |
 | [Go-Jek](https://www.gojek.io/careers/) | Tanjong Pagar | Summer | No tech internship positions listed currently |
 | [Goldman Sachs](https://www.goldmansachs.com/careers/students/programs/asia-pacific/summer-analyst.html) | Tanjong Pagar | Summer | Closes 11 Oct 2021
-| [Google](https://careers.google.com/jobs/results/?employment_type=INTERN&location=Singapore&q=) | Pasir Panjang | Summer | SWE and Data Center Technician Internships | Within 12-18 months of completing a Bachelor's or Master's degree
+| [Google](https://careers.google.com/jobs/results/?employment_type=INTERN&location=Singapore&q=) | Pasir Panjang | Summer | SWE and Data Center Technician Positions | Within 12-18 months of completing a Bachelor's or Master's degree
 | [Google (STEP)](https://careers.google.com/jobs/results/111206685625721542/) | Pasir Panjang | Summer | Closes 30 Sep 2021 | Only open to second year undergraduate students
 | [GovTech](https://sggovterp.wd102.myworkdayjobs.com/PublicServiceCareers/4/refreshFacet/318c8bb6f553100021d223d9780d30be) | Depends on team | Summer | Multiple positions open |
 | [Grab](https://grab.careers/jobs/) | Marina One | Unknown | 6-month Jan-Jun; Engineering and Data Science Positions |
 | [HopeTechnik](https://www.hopetechnik.com/careers/) | Jurong | All-year around | Software Engineering, Technical Analyst & Mechanical Engineering Positions |
 | [JPMorgan](https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/job/210141619)| | Summer | Closes 31 Oct 2021 |
-| [Jump Trading](https://www.jumptrading.com/jobs.html) | Downtown | Summer | Tech Ops & SWE internships |
-| [Lazada](https://www.lazada.com/en/careers/job-description/GP655404/) | Tanjong Pagar | Summer | Data Analyst position |
-| [Ninja Van](https://jobs.lever.co/ninjavan?location=Singapore%2C%20Singapore&department=Tech&commitment=Internship) | Alexandra | All-year-round | SWE Internships |
+| [Jump Trading](https://www.jumptrading.com/jobs.html) | Downtown | Summer | SWE and Tech Ops Positions |
+| [Lazada](https://www.lazada.com/en/careers/job-description/GP655404/) | Tanjong Pagar | Summer | Data Analyst Position |
+| [Ninja Van](https://jobs.lever.co/ninjavan?location=Singapore%2C%20Singapore&department=Tech&commitment=Internship) | Alexandra | All-year-round | |
 | [OpenGovProducts](https://opengovernmentproducts.recruitee.com/o/software-engineering-intern)| Funan | All-year-round | Only Singaporeans or PRs allowed |
 | [PayPal](https://jobsearch.paypal-corp.com/en-US/search?facetcountry=sg&location=Singapore&facetcategory=internship) | Promenade | All-year around | |
 | [SEA (Garena)](https://career.seagroup.com/programs?pos=LIP-area) | One-North | All-year around | |

--- a/README.md
+++ b/README.md
@@ -14,30 +14,30 @@ To contribute:
 ## List of positions
 | Name | Location | Application Period | Notes  |
 |------|----------|--------------------|--------|
-| [Apple](https://jobs.apple.com/en-sg/details/200272499/2022-apple-internship-information-systems-and-technology?team=STDNT)  | One-North | Summer 2022 | 6-month long, Information Systems and Technology Internship |
+| [Apple](https://jobs.apple.com/en-sg/details/200272499/2022-apple-internship-information-systems-and-technology?team=STDNT)  | One-North | Summer | 6-month long, Information Systems and Technology Internship |
 | [Basis](https://basis-ai.com/get-in-touch)  | Tanjong Pagar |  Unknown |  No position listed but they do accept interns |
-| [ByteDance](https://bytedance.feishu.cn/docs/doccnhFYuO21dvlpC3ZVg4pTZ50#ruVHxU)  | Tanjong Pagar | Summer & Spring |  |
+| [ByteDance & TikTok](https://bytedance.feishu.cn/docs/doccnhFYuO21dvlpC3ZVg4pTZ50#ruVHxU)  | Tanjong Pagar | Summer & Spring | Multiple positions open |
 | [Carousell](https://careers.carousell.com/job-posting/?gh_jid=2980636)  | Tanjong Pagar | Unknown | Software Engineer Internship, Android |
 | [Circles.Life](https://www.circles.life/sg/job-board/)  | Unknown | January 2021 | iOS, Android, Web and general SWE positions |
 | [CVWO](https://www.comp.nus.edu.sg/~vwo/contact.html)  | NUS | Summer | SWE Intern (Predominantly for NUS students) |
-| [DRW](https://drw.com/careers/listings?location=Singapore&language=English&category=Campus) | Downtown/Marina Bay | Summer | No internship positions listed currently |
-| [Facebook](https://www.facebook.com/careers/jobs/?offices%5B0%5D=Singapore&roles%5B0%5D=intern&is_leadership=0&is_in_page=0) | Marina One | Summer | No internship positions listed currently |
+| [DRW](https://drw.com/careers/listings?location=Singapore&language=English&category=Campus) | Downtown/Marina Bay | Summer | Software Developer Internship |
+| [Facebook](https://www.facebook.com/careers/jobs/?offices%5B0%5D=Singapore&roles%5B0%5D=intern&is_leadership=0&is_in_page=0) | Marina One | Summer | Software Engineer and Enterprise Engineer Internships |
 | [FireVisor](https://angel.co/firevisor/jobs) | One-North / City Hall | All-year around | No tech internship positions listed currently |
 | [Foodpanda](https://boards.greenhouse.io/foodpandasingapore/jobs/2399062) | Unknown | All-year around | SWE Intern |
 | [Go-Jek](https://www.gojek.io/careers/) | Tanjong Pagar | Summer | No tech internship positions listed currently |
-| [Goldman Sachs](https://www.goldmansachs.com/careers/students/programs/asia-pacific/summer-analyst.html) | Tanjong Pagar | Summer | Closes 11 Oct 
-| [Google](https://careers.google.com/jobs/results/138610814874460870/)  | Pasir Panjang | Summer | Opens 1st September 2020 | Within 12-18 months of completing a Bachelor's or Master's degree
-| [Google (STEP)](https://careers.google.com/jobs/results/111206685625721542-student-training-in-engineering-program-step-intern-2022/?fbclid=IwAR3n2u_Sqg5juJVXduLRRYFBlICbr7BXsjMQi-tFjmUNrCEhZK8_Y1xT1ew%3Ffrom%3Dtgmar&page=4&utm_campaign=google_jobs_apply&utm_medium=organic&utm_source=google_jobs_apply)  | Pasir Panjang | Summer | Opens 1st September 2021 | Only open to second year  undergraduate students
-| [GovTech](https://sggovterp.wd102.myworkdayjobs.com/PublicServiceCareers/4/refreshFacet/318c8bb6f553100021d223d9780d30be) | Depends on team | Summer  | Multiple positions open |
-| [Grab](https://grab.careers/jobs/)                                                                                        | Marina One      | Unknown | No tech internship positions listed currently  |
-| [HopeTechnik](https://www.hopetechnik.com/careers/) | Jurong | All-year around| Software Engineering, Technical Analyst & Mechanical Engineering positions |
-| [JPMorgan](https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/job/210014831)| | Summer| October 30, 2020|
-| [Jump Trading](https://www.jumptrading.com/jobs.html)  | Downtown | Summer | Tech Ops && SWE internships |
+| [Goldman Sachs](https://www.goldmansachs.com/careers/students/programs/asia-pacific/summer-analyst.html) | Tanjong Pagar | Summer | Closes 11 Oct 2021
+| [Google](https://careers.google.com/jobs/results/?employment_type=INTERN&location=Singapore&q=)  | Pasir Panjang | Summer | SWE and Data Center Technician Internships | Within 12-18 months of completing a Bachelor's or Master's degree
+| [Google (STEP)](https://careers.google.com/jobs/results/111206685625721542/)  | Pasir Panjang | Summer | Closes 30 Sep 2021 | Only open to second year  undergraduate students
+| [GovTech](https://sggovterp.wd102.myworkdayjobs.com/PublicServiceCareers/4/refreshFacet/318c8bb6f553100021d223d9780d30be) | Depends on team | Summer | Multiple positions open |
+| [Grab](https://grab.careers/jobs/) | Marina One | Unknown | 6-month Jan-Jun; Engineering and Data Science Positions |
+| [HopeTechnik](https://www.hopetechnik.com/careers/) | Jurong | All-year around | Software Engineering, Technical Analyst & Mechanical Engineering Positions |
+| [JPMorgan](https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/job/210141619)| | Summer | Closes 31 Oct 2021 |
+| [Jump Trading](https://www.jumptrading.com/jobs.html) | Downtown | Summer | Tech Ops & SWE internships |
 | [Lazada](https://www.lazada.com/en/careers/job-description/GP655404/) | Tanjong Pagar | Summer | Data Analyst position |
 | [Ninja Van](https://jobs.lever.co/ninjavan?location=Singapore%2C%20Singapore&department=Tech&commitment=Internship) | Alexandra | All-year-round | SWE Internships |
 | [OpenGovProducts](https://opengovernmentproducts.recruitee.com/o/software-engineering-intern)| Funan | All-year-round | Only Singaporeans or PRs allowed |
 | [PayPal](https://jobsearch.paypal-corp.com/en-US/search?facetcountry=sg&location=Singapore&facetcategory=internship)  | Promenade | All-year around | |
-| [SEA(Garena)](https://career.seagroup.com/programs?pos=LIP-area)  | One-North | All-year around | |
+| [SEA (Garena)](https://career.seagroup.com/programs?pos=LIP-area)  | One-North | All-year around | |
 | [Seedly](https://careers.seedly.com/)  | One-North | Summer | Internship period is Sept-Dec 2020 or Jan-May 2021 |
 | [ShopBack](https://jobs.lever.co/shopback-2/3c60180b-6dd1-48a6-9d0e-4edf80be1fc3)  | One-North | Summer | Internship period is Sept-Dec 2020 or Jan-May 2021 |
 | [Shopee](https://careers.shopee.sg/job-detail/2336/) | Kent-Ridge | All-year around | |
@@ -45,7 +45,7 @@ To contribute:
 | [Titansoft](https://www.titansoft.com/en/career/current-openings?country=singapore&tag=3) | Outram Park | Summer | |
 | [Traverse](https://www.traverse.ai/about-us/contact) | Commonwealth  | Unknown | No position listed but they do accept interns |
 | [Twitter](https://careers.twitter.com/content/careers-twitter/en/jobs.html#location=careers-twitter%3Asr%2Foffice%2Fsingapore)  | Raffles Place/Downtown | Summer | |
-| [VISA](https://www.visa.com.sg/careers/job-details.jobid.743999675740916.deptid.868537.html)  | Paya Lebar | Summer | |
-| [ViSenze](https://apply.workable.com/visenze/?lng=en)  | One-North | Unknown | Full Stack and R&D internships |
+| [VISA](https://www.visa.com.sg/careers/job-details.jobid.743999766563075.deptid.1146810.html) | Paya Lebar | Summer | |
+| [ViSenze](https://apply.workable.com/visenze/?lng=en) | One-North | Unknown | Full Stack and R&D internships |
 | [Yitu Tech](https://www.yitutech.com/en/career?mode=campus) | Pasir Panjang | Summer/Winter | |
-| [Zendesk](https://www.zendesk.com/jobs/singapore/)  | Commonwealth | Summer | No intern positions listed |
+| [Zendesk](https://www.zendesk.com/jobs/singapore/) | Commonwealth | Summer | No intern positions listed |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To contribute:
 | [GovTech](https://sggovterp.wd102.myworkdayjobs.com/PublicServiceCareers/4/refreshFacet/318c8bb6f553100021d223d9780d30be) | Depends on team | Summer | Multiple positions open |
 | [Grab](https://grab.careers/jobs/) | Marina One | Unknown | 6-month Jan-Jun; Engineering and Data Science Positions |
 | [HopeTechnik](https://www.hopetechnik.com/careers/) | Jurong | All-year around | Software Engineering, Technical Analyst & Mechanical Engineering Positions |
+| [IBM](https://careers.ibm.com/job/13539646/internship-software-developer-jan-to-may-jun-singapore-sg/?codes=IBM_CareerWebSite) | Changi Business Park | Unknown | 6-month Jan-Jun |
 | [JPMorgan](https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/job/210141619)| | Summer | Closes 31 Oct 2021 |
 | [Jump Trading](https://www.jumptrading.com/jobs.html) | Downtown | Summer | SWE and Tech Ops Positions |
 | [Lazada](https://www.lazada.com/en/careers/job-description/GP655404/) | Tanjong Pagar | Summer | Data Analyst Position |

--- a/README.md
+++ b/README.md
@@ -12,22 +12,22 @@ To contribute:
 
 
 ## List of positions
-| Name | Location | Application Period | Notes  |
-|------|----------|--------------------|--------|
-| [Apple](https://jobs.apple.com/en-sg/details/200272499/2022-apple-internship-information-systems-and-technology?team=STDNT)  | One-North | Summer | 6-month long, Information Systems and Technology Internship |
-| [Basis](https://basis-ai.com/get-in-touch)  | Tanjong Pagar |  Unknown |  No position listed but they do accept interns |
-| [ByteDance & TikTok](https://bytedance.feishu.cn/docs/doccnhFYuO21dvlpC3ZVg4pTZ50#ruVHxU)  | Tanjong Pagar | Summer & Spring | Multiple positions open |
-| [Carousell](https://careers.carousell.com/job-posting/?gh_jid=2980636)  | Tanjong Pagar | Unknown | Software Engineer Internship, Android |
-| [Circles.Life](https://www.circles.life/sg/job-board/)  | Unknown | January 2021 | iOS, Android, Web and general SWE positions |
-| [CVWO](https://www.comp.nus.edu.sg/~vwo/contact.html)  | NUS | Summer | SWE Intern (Predominantly for NUS students) |
+| Name | Location | Application Period | Notes |
+|------|----------|--------------------|-------|
+| [Apple](https://jobs.apple.com/en-sg/details/200272499/2022-apple-internship-information-systems-and-technology?team=STDNT) | One-North | Summer | 6-month long, Information Systems and Technology Internship |
+| [Basis](https://basis-ai.com/get-in-touch) | Tanjong Pagar | Unknown | No position listed but they do accept interns |
+| [ByteDance & TikTok](https://bytedance.feishu.cn/docs/doccnhFYuO21dvlpC3ZVg4pTZ50#ruVHxU) | Tanjong Pagar | Summer & Spring | Multiple positions open |
+| [Carousell](https://careers.carousell.com/job-posting/?gh_jid=2980636) | Tanjong Pagar | Unknown | Software Engineer Internship, Android |
+| [Circles.Life](https://www.circles.life/sg/job-board/) | Unknown | January 2021 | iOS, Android, Web and general SWE positions |
+| [CVWO](https://www.comp.nus.edu.sg/~vwo/contact.html) | NUS | Summer | SWE Intern (Predominantly for NUS students) |
 | [DRW](https://drw.com/careers/listings?location=Singapore&language=English&category=Campus) | Downtown/Marina Bay | Summer | Software Developer Internship |
 | [Facebook](https://www.facebook.com/careers/jobs/?offices%5B0%5D=Singapore&roles%5B0%5D=intern&is_leadership=0&is_in_page=0) | Marina One | Summer | Software Engineer and Enterprise Engineer Internships |
 | [FireVisor](https://angel.co/firevisor/jobs) | One-North / City Hall | All-year around | No tech internship positions listed currently |
 | [Foodpanda](https://boards.greenhouse.io/foodpandasingapore/jobs/2399062) | Unknown | All-year around | SWE Intern |
 | [Go-Jek](https://www.gojek.io/careers/) | Tanjong Pagar | Summer | No tech internship positions listed currently |
 | [Goldman Sachs](https://www.goldmansachs.com/careers/students/programs/asia-pacific/summer-analyst.html) | Tanjong Pagar | Summer | Closes 11 Oct 2021
-| [Google](https://careers.google.com/jobs/results/?employment_type=INTERN&location=Singapore&q=)  | Pasir Panjang | Summer | SWE and Data Center Technician Internships | Within 12-18 months of completing a Bachelor's or Master's degree
-| [Google (STEP)](https://careers.google.com/jobs/results/111206685625721542/)  | Pasir Panjang | Summer | Closes 30 Sep 2021 | Only open to second year  undergraduate students
+| [Google](https://careers.google.com/jobs/results/?employment_type=INTERN&location=Singapore&q=) | Pasir Panjang | Summer | SWE and Data Center Technician Internships | Within 12-18 months of completing a Bachelor's or Master's degree
+| [Google (STEP)](https://careers.google.com/jobs/results/111206685625721542/) | Pasir Panjang | Summer | Closes 30 Sep 2021 | Only open to second year undergraduate students
 | [GovTech](https://sggovterp.wd102.myworkdayjobs.com/PublicServiceCareers/4/refreshFacet/318c8bb6f553100021d223d9780d30be) | Depends on team | Summer | Multiple positions open |
 | [Grab](https://grab.careers/jobs/) | Marina One | Unknown | 6-month Jan-Jun; Engineering and Data Science Positions |
 | [HopeTechnik](https://www.hopetechnik.com/careers/) | Jurong | All-year around | Software Engineering, Technical Analyst & Mechanical Engineering Positions |
@@ -36,15 +36,15 @@ To contribute:
 | [Lazada](https://www.lazada.com/en/careers/job-description/GP655404/) | Tanjong Pagar | Summer | Data Analyst position |
 | [Ninja Van](https://jobs.lever.co/ninjavan?location=Singapore%2C%20Singapore&department=Tech&commitment=Internship) | Alexandra | All-year-round | SWE Internships |
 | [OpenGovProducts](https://opengovernmentproducts.recruitee.com/o/software-engineering-intern)| Funan | All-year-round | Only Singaporeans or PRs allowed |
-| [PayPal](https://jobsearch.paypal-corp.com/en-US/search?facetcountry=sg&location=Singapore&facetcategory=internship)  | Promenade | All-year around | |
-| [SEA (Garena)](https://career.seagroup.com/programs?pos=LIP-area)  | One-North | All-year around | |
-| [Seedly](https://careers.seedly.com/)  | One-North | Summer | Internship period is Sept-Dec 2020 or Jan-May 2021 |
-| [ShopBack](https://jobs.lever.co/shopback-2/3c60180b-6dd1-48a6-9d0e-4edf80be1fc3)  | One-North | Summer | Internship period is Sept-Dec 2020 or Jan-May 2021 |
+| [PayPal](https://jobsearch.paypal-corp.com/en-US/search?facetcountry=sg&location=Singapore&facetcategory=internship) | Promenade | All-year around | |
+| [SEA (Garena)](https://career.seagroup.com/programs?pos=LIP-area) | One-North | All-year around | |
+| [Seedly](https://careers.seedly.com/) | One-North | Summer | Internship period is Sept-Dec 2020 or Jan-May 2021 |
+| [ShopBack](https://jobs.lever.co/shopback-2/3c60180b-6dd1-48a6-9d0e-4edf80be1fc3) | One-North | Summer | Internship period is Sept-Dec 2020 or Jan-May 2021 |
 | [Shopee](https://careers.shopee.sg/job-detail/2336/) | Kent-Ridge | All-year around | |
 | [Stripe](https://stripe.com/jobs/listing/software-engineering-intern/3368637) | Outram Park | Summer | |
 | [Titansoft](https://www.titansoft.com/en/career/current-openings?country=singapore&tag=3) | Outram Park | Summer | |
-| [Traverse](https://www.traverse.ai/about-us/contact) | Commonwealth  | Unknown | No position listed but they do accept interns |
-| [Twitter](https://careers.twitter.com/content/careers-twitter/en/jobs.html#location=careers-twitter%3Asr%2Foffice%2Fsingapore)  | Raffles Place/Downtown | Summer | |
+| [Traverse](https://www.traverse.ai/about-us/contact) | Commonwealth | Unknown | No position listed but they do accept interns |
+| [Twitter](https://careers.twitter.com/content/careers-twitter/en/jobs.html#location=careers-twitter%3Asr%2Foffice%2Fsingapore) | Raffles Place/Downtown | Summer | |
 | [VISA](https://www.visa.com.sg/careers/job-details.jobid.743999766563075.deptid.1146810.html) | Paya Lebar | Summer | |
 | [ViSenze](https://apply.workable.com/visenze/?lng=en) | One-North | Unknown | Full Stack and R&D internships |
 | [Yitu Tech](https://www.yitutech.com/en/career?mode=campus) | Pasir Panjang | Summer/Winter | |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To contribute:
 | [ByteDance & TikTok](https://bytedance.feishu.cn/docs/doccnhFYuO21dvlpC3ZVg4pTZ50#ruVHxU) | Tanjong Pagar | Summer & Spring | Multiple positions open |
 | [Carousell](https://careers.carousell.com/job-posting/?gh_jid=2980636) | Tanjong Pagar | Unknown | Software Engineer Internship, Android |
 | [Circles.Life](https://www.circles.life/sg/job-board/) | Unknown | January 2021 | iOS, Android, Web and general SWE positions |
+| [Citi](https://jobs.citi.com/job/singapore/icg-technology-software-development-2022-summer-analyst-singapore/287/12532326144) | Marina View | Summer | Software Development under their Summer Analyst Program |
 | [CVWO](https://www.comp.nus.edu.sg/~vwo/contact.html) | NUS | Summer | SWE Intern (Predominantly for NUS students) |
 | [DRW](https://drw.com/careers/job/software-developer-intern-1933017/) | Downtown/Marina Bay | Summer | |
 | [Facebook](https://www.facebook.com/careers/jobs/?offices%5B0%5D=Singapore&roles%5B0%5D=intern&is_leadership=0&is_in_page=0) | Marina One | Summer | Software Engineer and Enterprise Engineer Positions |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To contribute:
 | [Carousell](https://careers.carousell.com/job-posting/?gh_jid=2980636) | Tanjong Pagar | Unknown | Software Engineer Internship, Android |
 | [Circles.Life](https://www.circles.life/sg/job-board/) | Unknown | January 2021 | iOS, Android, Web and general SWE positions |
 | [CVWO](https://www.comp.nus.edu.sg/~vwo/contact.html) | NUS | Summer | SWE Intern (Predominantly for NUS students) |
-| [DRW](https://drw.com/careers/listings?location=Singapore&language=English&category=Campus) | Downtown/Marina Bay | Summer | Software Developer Internship |
+| [DRW](https://drw.com/careers/job/software-developer-intern-1933017/) | Downtown/Marina Bay | Summer | |
 | [Facebook](https://www.facebook.com/careers/jobs/?offices%5B0%5D=Singapore&roles%5B0%5D=intern&is_leadership=0&is_in_page=0) | Marina One | Summer | Software Engineer and Enterprise Engineer Internships |
 | [FireVisor](https://angel.co/firevisor/jobs) | One-North / City Hall | All-year around | No tech internship positions listed currently |
 | [Foodpanda](https://boards.greenhouse.io/foodpandasingapore/jobs/2399062) | Unknown | All-year around | SWE Intern |


### PR DESCRIPTION
### Key changes

- Updated links and openings for multiple positions:
   - DRW: Software Developer position just opened.
   - Facebook: SWE and EE positions just opened.
   - Google: SWE and Data Center positions just opened.
   - Google STEP: Changed to mention when it's closing instead of when it's opening, as it has already opened.
   - Grab: 6-month positions just opened.
   - JPMorgan: 2021 SWE position just opened.
   - VISA: Updated outdated 2020 link to 2021 link.
- Added new positions:
   - Citi
   - IBM
   - Motional
   - Temasek

### Other misc changes

- Standardised formatting/spacing of the table.
- Standardised Notes column, in terms of the phrasing and terminology.